### PR TITLE
change config filename from `.contentful.json` to `contentful.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ public
 .cache
 
 # contentful config file
-.contentful.json
+contentful.json

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,8 @@
 let contentfulConfig
 
 try {
-  // Load the Contentful config from the .contentful.json
-  contentfulConfig = require('./.contentful')
+  // Load the Contentful config from the contentful.json
+  contentfulConfig = require('./contentful')
 } catch (_) {}
 
 // Overwrite the Contentful config with environment variables if they exist

--- a/setup.js
+++ b/setup.js
@@ -64,7 +64,7 @@ fileRequest.then(response => {
 // we need to write a config file with a provided credentials (space id and CDA token)
 // so that `npm run dev` connects to your space.
 function saveConfigFile ({ spaceId, deliveryToken }) {
-  const configFilePath = path.resolve(__dirname, '.contentful.json')
+  const configFilePath = path.resolve(__dirname, 'contentful.json')
   console.log('')
   console.log('Writing config file...')
   console.log('')


### PR DESCRIPTION
beginner programmers and non technical people have given feedback that they can't find `.contentful.json` or `.contentful.sample.json` and we found out this is largely due to macOS' default behavior of hiding files that start with a period. This change will clarify the setup and make it easier to find and change the configuration for beginners.