### PR TITLE
Pass ownerNodeId to Gatsby plugin for content sync.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,6 +13,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
           nodes {
             title
             slug
+            id
           }
         }
       }
@@ -47,6 +48,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
           previousPostSlug,
           nextPostSlug,
         },
+        ownerNodeId: post.id,
       })
     })
   }


### PR DESCRIPTION
Content sync support requires ownerNodeId is passed into the create node method on the gatsby plugin side. This PR ensures that a node unique id is passed into the page create call.