### PR TITLE
fix: bump source plugin package version to fix builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "gatsby-plugin-image": "^2.0.0",
         "gatsby-plugin-react-helmet": "^5.0.0",
         "gatsby-plugin-sharp": "^4.0.0",
-        "gatsby-source-contentful": "^6.0.0",
+        "gatsby-source-contentful": "^6.1.3",
         "gatsby-transformer-remark": "^5.0.0",
         "gatsby-transformer-sharp": "^4.0.0",
         "gh-pages": "^3.1.0",
@@ -14713,9 +14713,9 @@
       }
     },
     "node_modules/gatsby-core-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.0.0.tgz",
-      "integrity": "sha512-MEQAgP+/ddDTOjcfRhyZenLfr6q3nyh01muI6QTgz0qAFsbS50lZh9SbczgpuKnb6qiST1KR0OUIYTaBFXfB2g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.1.2.tgz",
+      "integrity": "sha512-l3LUdGNDlM3fLrdxRUGnsd/Szu9e8yLEL/pZIV2LuhTHMNwjOStiycEQivezsUhHNPobep1r5t4yWzP6r2cw/Q==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -15079,9 +15079,9 @@
       }
     },
     "node_modules/gatsby-plugin-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-2.0.0.tgz",
-      "integrity": "sha512-RN++hR/gU6orPHlnDM3CUd4DnDdTcGS3vkjHnAvo+Wli7H8yHEt4baoK20f/V3AOOCxwen8TypFH3Uy5iVAjyg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-2.1.1.tgz",
+      "integrity": "sha512-LzLLSg9CWCi4qMqYNYkt8vAoySkNWKfB8QKJKnpU5qzo/3vjZAx9iWHmoNRYLCCHg1bgJn2Kr5cwOMYAEJspyg==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "joi": "^17.4.2"
@@ -15212,9 +15212,9 @@
       }
     },
     "node_modules/gatsby-source-contentful": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-6.0.0.tgz",
-      "integrity": "sha512-QroAi4SVWe9YnDCMEdp1fDEu9qpO/jnp0Jv6xBb9OkdTUpa81tgOZwLhkOdjyq2MRXBlHMjPsrT4AYzjGzDwkA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-6.1.3.tgz",
+      "integrity": "sha512-/gIilhjNWESdbTuFSbWcyPCtnjhFl0nnS7uCZoU/fyhdh9KDDDGcFWPVh8rCkLOY19V8xJmZwG5ApD24YkPVWA==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@contentful/rich-text-react-renderer": "^14.1.3",
@@ -15226,9 +15226,9 @@
         "common-tags": "^1.8.0",
         "contentful": "^8.4.2",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.0.0",
-        "gatsby-plugin-utils": "^2.0.0",
-        "gatsby-source-filesystem": "^4.0.0",
+        "gatsby-core-utils": "^3.1.2",
+        "gatsby-plugin-utils": "^2.1.1",
+        "gatsby-source-filesystem": "^4.1.2",
         "is-online": "^8.5.1",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.21",
@@ -15247,16 +15247,16 @@
       }
     },
     "node_modules/gatsby-source-filesystem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.0.0.tgz",
-      "integrity": "sha512-LQPTaAOt2i740qzAtR9oFk8h2a60JZv90nJqfLxgVbHdbRiH1KnCbXLYMmzhsLfhfOUiwG5KMOT7icZpESRNnA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.1.2.tgz",
+      "integrity": "sha512-f4oa3+3i3Y2IgTwHaI7EO9cQO9YW4tx3h89gnSKMeD5QjofQGivBjGsGETFMCa16kKARAdLGEITdl09A8ltcyQ==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "chokidar": "^3.5.2",
         "fastq": "^1.11.1",
         "file-type": "^16.5.3",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.0.0",
+        "gatsby-core-utils": "^3.1.2",
         "got": "^9.6.0",
         "md5-file": "^5.0.0",
         "mime": "^2.5.2",
@@ -44872,9 +44872,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.0.0.tgz",
-      "integrity": "sha512-MEQAgP+/ddDTOjcfRhyZenLfr6q3nyh01muI6QTgz0qAFsbS50lZh9SbczgpuKnb6qiST1KR0OUIYTaBFXfB2g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.1.2.tgz",
+      "integrity": "sha512-l3LUdGNDlM3fLrdxRUGnsd/Szu9e8yLEL/pZIV2LuhTHMNwjOStiycEQivezsUhHNPobep1r5t4yWzP6r2cw/Q==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -45154,9 +45154,9 @@
       }
     },
     "gatsby-plugin-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-2.0.0.tgz",
-      "integrity": "sha512-RN++hR/gU6orPHlnDM3CUd4DnDdTcGS3vkjHnAvo+Wli7H8yHEt4baoK20f/V3AOOCxwen8TypFH3Uy5iVAjyg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-2.1.1.tgz",
+      "integrity": "sha512-LzLLSg9CWCi4qMqYNYkt8vAoySkNWKfB8QKJKnpU5qzo/3vjZAx9iWHmoNRYLCCHg1bgJn2Kr5cwOMYAEJspyg==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "joi": "^17.4.2"
@@ -45260,9 +45260,9 @@
       }
     },
     "gatsby-source-contentful": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-6.0.0.tgz",
-      "integrity": "sha512-QroAi4SVWe9YnDCMEdp1fDEu9qpO/jnp0Jv6xBb9OkdTUpa81tgOZwLhkOdjyq2MRXBlHMjPsrT4AYzjGzDwkA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-6.1.3.tgz",
+      "integrity": "sha512-/gIilhjNWESdbTuFSbWcyPCtnjhFl0nnS7uCZoU/fyhdh9KDDDGcFWPVh8rCkLOY19V8xJmZwG5ApD24YkPVWA==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@contentful/rich-text-react-renderer": "^14.1.3",
@@ -45274,9 +45274,9 @@
         "common-tags": "^1.8.0",
         "contentful": "^8.4.2",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.0.0",
-        "gatsby-plugin-utils": "^2.0.0",
-        "gatsby-source-filesystem": "^4.0.0",
+        "gatsby-core-utils": "^3.1.2",
+        "gatsby-plugin-utils": "^2.1.1",
+        "gatsby-source-filesystem": "^4.1.2",
         "is-online": "^8.5.1",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.21",
@@ -45286,16 +45286,16 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.0.0.tgz",
-      "integrity": "sha512-LQPTaAOt2i740qzAtR9oFk8h2a60JZv90nJqfLxgVbHdbRiH1KnCbXLYMmzhsLfhfOUiwG5KMOT7icZpESRNnA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.1.2.tgz",
+      "integrity": "sha512-f4oa3+3i3Y2IgTwHaI7EO9cQO9YW4tx3h89gnSKMeD5QjofQGivBjGsGETFMCa16kKARAdLGEITdl09A8ltcyQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "chokidar": "^3.5.2",
         "fastq": "^1.11.1",
         "file-type": "^16.5.3",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.0.0",
+        "gatsby-core-utils": "^3.1.2",
         "got": "^9.6.0",
         "md5-file": "^5.0.0",
         "mime": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gatsby-plugin-image": "^2.0.0",
     "gatsby-plugin-react-helmet": "^5.0.0",
     "gatsby-plugin-sharp": "^4.0.0",
-    "gatsby-source-contentful": "^6.0.0",
+    "gatsby-source-contentful": "^6.1.3",
     "gatsby-transformer-remark": "^5.0.0",
     "gatsby-transformer-sharp": "^4.0.0",
     "gh-pages": "^3.1.0",


### PR DESCRIPTION
A regression for builds was introduced to `gatsby-source-contentful` via https://github.com/gatsbyjs/gatsby/pull/33482 as there was a bug in the `gatsby-core-utils` helper that PR introduced. This would fail preview builds and potentially normal builds as well. This morning a fix was released and bumping the version in this PR fixes the issue. 