### PR TITLE
fix: bump gatsby-source-contentful version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "gatsby-plugin-image": "^2.0.0",
         "gatsby-plugin-react-helmet": "^5.0.0",
         "gatsby-plugin-sharp": "^4.0.0",
-        "gatsby-source-contentful": "^6.1.3",
+        "gatsby-source-contentful": "^6.1.4",
         "gatsby-transformer-remark": "^5.0.0",
         "gatsby-transformer-sharp": "^4.0.0",
         "gh-pages": "^3.1.0",
@@ -14713,9 +14713,9 @@
       }
     },
     "node_modules/gatsby-core-utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.1.2.tgz",
-      "integrity": "sha512-l3LUdGNDlM3fLrdxRUGnsd/Szu9e8yLEL/pZIV2LuhTHMNwjOStiycEQivezsUhHNPobep1r5t4yWzP6r2cw/Q==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.1.3.tgz",
+      "integrity": "sha512-+pg2i3DYVLzmJ/67SVGM+zVxerilGCbcgVxDoN58Y+Htv5TwogUWzPymfoFrJEsWGhlVKlYq7I8jVWSXPzwMHw==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -15212,9 +15212,9 @@
       }
     },
     "node_modules/gatsby-source-contentful": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-6.1.3.tgz",
-      "integrity": "sha512-/gIilhjNWESdbTuFSbWcyPCtnjhFl0nnS7uCZoU/fyhdh9KDDDGcFWPVh8rCkLOY19V8xJmZwG5ApD24YkPVWA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-6.1.4.tgz",
+      "integrity": "sha512-YiarFhtaDmAhlJFu9Hjw8CuYC0NQqi+OkJY8OwOmVJL9fWIUHtVCp092tG793hnlSPbq0fGRP6cZqpLU0XjwNg==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@contentful/rich-text-react-renderer": "^14.1.3",
@@ -15226,9 +15226,9 @@
         "common-tags": "^1.8.0",
         "contentful": "^8.4.2",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.1.2",
+        "gatsby-core-utils": "^3.1.3",
         "gatsby-plugin-utils": "^2.1.1",
-        "gatsby-source-filesystem": "^4.1.2",
+        "gatsby-source-filesystem": "^4.1.3",
         "is-online": "^8.5.1",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.21",
@@ -15247,16 +15247,16 @@
       }
     },
     "node_modules/gatsby-source-filesystem": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.1.2.tgz",
-      "integrity": "sha512-f4oa3+3i3Y2IgTwHaI7EO9cQO9YW4tx3h89gnSKMeD5QjofQGivBjGsGETFMCa16kKARAdLGEITdl09A8ltcyQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.1.3.tgz",
+      "integrity": "sha512-X3r58Mwq8jXlnA1ZJmzx2bynE2iJQKsiGyDqnC4T606LbMLnIwLLyu6n9oQ1K41zXT7KtEp6r+12BhgsTTp97A==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "chokidar": "^3.5.2",
         "fastq": "^1.11.1",
         "file-type": "^16.5.3",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.1.2",
+        "gatsby-core-utils": "^3.1.3",
         "got": "^9.6.0",
         "md5-file": "^5.0.0",
         "mime": "^2.5.2",
@@ -44872,9 +44872,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.1.2.tgz",
-      "integrity": "sha512-l3LUdGNDlM3fLrdxRUGnsd/Szu9e8yLEL/pZIV2LuhTHMNwjOStiycEQivezsUhHNPobep1r5t4yWzP6r2cw/Q==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.1.3.tgz",
+      "integrity": "sha512-+pg2i3DYVLzmJ/67SVGM+zVxerilGCbcgVxDoN58Y+Htv5TwogUWzPymfoFrJEsWGhlVKlYq7I8jVWSXPzwMHw==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -45260,9 +45260,9 @@
       }
     },
     "gatsby-source-contentful": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-6.1.3.tgz",
-      "integrity": "sha512-/gIilhjNWESdbTuFSbWcyPCtnjhFl0nnS7uCZoU/fyhdh9KDDDGcFWPVh8rCkLOY19V8xJmZwG5ApD24YkPVWA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-6.1.4.tgz",
+      "integrity": "sha512-YiarFhtaDmAhlJFu9Hjw8CuYC0NQqi+OkJY8OwOmVJL9fWIUHtVCp092tG793hnlSPbq0fGRP6cZqpLU0XjwNg==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@contentful/rich-text-react-renderer": "^14.1.3",
@@ -45274,9 +45274,9 @@
         "common-tags": "^1.8.0",
         "contentful": "^8.4.2",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.1.2",
+        "gatsby-core-utils": "^3.1.3",
         "gatsby-plugin-utils": "^2.1.1",
-        "gatsby-source-filesystem": "^4.1.2",
+        "gatsby-source-filesystem": "^4.1.3",
         "is-online": "^8.5.1",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.21",
@@ -45286,16 +45286,16 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.1.2.tgz",
-      "integrity": "sha512-f4oa3+3i3Y2IgTwHaI7EO9cQO9YW4tx3h89gnSKMeD5QjofQGivBjGsGETFMCa16kKARAdLGEITdl09A8ltcyQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.1.3.tgz",
+      "integrity": "sha512-X3r58Mwq8jXlnA1ZJmzx2bynE2iJQKsiGyDqnC4T606LbMLnIwLLyu6n9oQ1K41zXT7KtEp6r+12BhgsTTp97A==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "chokidar": "^3.5.2",
         "fastq": "^1.11.1",
         "file-type": "^16.5.3",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.1.2",
+        "gatsby-core-utils": "^3.1.3",
         "got": "^9.6.0",
         "md5-file": "^5.0.0",
         "mime": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gatsby-plugin-image": "^2.0.0",
     "gatsby-plugin-react-helmet": "^5.0.0",
     "gatsby-plugin-sharp": "^4.0.0",
-    "gatsby-source-contentful": "^6.1.3",
+    "gatsby-source-contentful": "^6.1.4",
     "gatsby-transformer-remark": "^5.0.0",
     "gatsby-transformer-sharp": "^4.0.0",
     "gh-pages": "^3.1.0",


### PR DESCRIPTION
There was an additional issue after https://github.com/contentful/starter-gatsby-blog/pull/179 so this PR bumps to latest `gatsby-source-contentful` to fix that. See https://github.com/gatsbyjs/gatsby/discussions/33933#discussioncomment-1644230 for more info