### PR TITLE
Remove pathPrefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -39,7 +39,6 @@ module.exports = {
     title: "Gatsby Contentful Starter",
     description: "Official Contentful Gatsby Starter",
   },
-  pathPrefix: "/gatsby-contentful-starter",
   plugins: [
     "gatsby-transformer-remark",
     "gatsby-transformer-sharp",


### PR DESCRIPTION
The pathPrefix isn't used and breaks trying to serve the built site by returning a 404 on /.