### PR TITLE
fix: use consistent env vars

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -49,9 +49,7 @@ const questions = [
     name: "accessToken",
     when:
       !argv.accessToken &&
-      !process.env.CONTENTFUL_ACCESS_TOKEN &&
-      !argv.deliveryToken &&
-      !process.env.CONTENTFUL_DELIVERY_TOKEN,
+      !process.env.CONTENTFUL_ACCESS_TOKEN,
     message: "Your Content Delivery API access token",
   },
 ];
@@ -62,41 +60,38 @@ inquirer
     const {
       CONTENTFUL_SPACE_ID,
       CONTENTFUL_ACCESS_TOKEN,
-      CONTENTFUL_DELIVERY_TOKEN,
     } = process.env;
 
-    // env vars are given precedence followed by args provided to the setup
-    // followed by input given to prompts displayed by the setup script
-    spaceId = CONTENTFUL_SPACE_ID || argv.spaceId || spaceId;
+    let config = {
+      spaceId: CONTENTFUL_SPACE_ID || argv.spaceId || spaceId,
+      accessToken: CONTENTFUL_ACCESS_TOKEN ||
+        argv.accessToken ||
+        accessToken,
+    }
+
     managementToken = argv.managementToken || managementToken;
-    // Some scripts that set up this repo use `deliveryToken` and
-    // `CONTENTFUL_DELIVERY_TOKEN`, instead of `accessToken` and
-    // `CONTENTFUL_ACCESS_TOKEN`. Until all scripts are updated to
-    // use `accessToken` and `CONTENTFUL_ACCESS_TOKEN` both variations
-    // will work.
-    accessToken =
-      CONTENTFUL_ACCESS_TOKEN ||
-      CONTENTFUL_DELIVERY_TOKEN ||
-      argv.accessToken ||
-      argv.deliveryToken ||
-      accessToken;
 
     console.log("Writing config file...");
     const configFiles = [`.env.development`, `.env.production`].map((file) =>
       path.join(__dirname, "..", file)
     );
 
-    const fileContents =
+    configFiles.forEach((file) => {
+      const fileArr =
       [
         `# All environment variables will be sourced`,
         `# and made available to gatsby-config.js, gatsby-node.js, etc.`,
         `# Do NOT commit this file to source control`,
-        `CONTENTFUL_SPACE_ID='${spaceId}'`,
-        `CONTENTFUL_ACCESS_TOKEN='${accessToken}'`,
-      ].join("\n") + "\n";
+        `CONTENTFUL_SPACE_ID='${config.spaceId}'`,
+        `CONTENTFUL_ACCESS_TOKEN='${config.accessToken}'`,
+      ];
 
-    configFiles.forEach((file) => {
-      writeFileSync(file, fileContents, "utf8");
+      writeFileSync(file, fileArr.concat(
+        file.includes('development') ? [
+          `# To add draft content preview, uncomment the below line and use the Content Preview API Access Token`,
+          `# CONTENTFUL_HOST='preview.contentful.com'`
+        ] : []
+      ).filter(Boolean).join("\n") + "\n", "utf8");
       console.log(`Config file ${chalk.yellow(file)} written`);
     });
     return { spaceId, managementToken };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,38 +2,6 @@ require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 });
 
-const contentfulConfig = {
-  spaceId: process.env.CONTENTFUL_SPACE_ID,
-  accessToken:
-    process.env.CONTENTFUL_ACCESS_TOKEN ||
-    process.env.CONTENTFUL_DELIVERY_TOKEN,
-};
-
-// If you want to use the preview API please define
-// CONTENTFUL_HOST and CONTENTFUL_PREVIEW_ACCESS_TOKEN in your
-// environment config.
-//
-// CONTENTFUL_HOST should map to `preview.contentful.com`
-// CONTENTFUL_PREVIEW_ACCESS_TOKEN should map to your
-// Content Preview API token
-//
-// For more information around the Preview API check out the documentation at
-// https://www.contentful.com/developers/docs/references/content-preview-api/#/reference/spaces/space/get-a-space/console/js
-//
-// To change back to the normal CDA, remove the CONTENTFUL_HOST variable from your environment.
-if (process.env.CONTENTFUL_HOST) {
-  contentfulConfig.host = process.env.CONTENTFUL_HOST;
-  contentfulConfig.accessToken = process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN;
-}
-
-const { spaceId, accessToken } = contentfulConfig;
-
-if (!spaceId || !accessToken) {
-  throw new Error(
-    "Contentful spaceId and the access token need to be provided."
-  );
-}
-
 module.exports = {
   siteMetadata: {
     title: "Gatsby Contentful Starter",
@@ -46,7 +14,11 @@ module.exports = {
     "gatsby-plugin-image",
     {
       resolve: "gatsby-source-contentful",
-      options: contentfulConfig,
+      options: {
+        spaceId: process.env.CONTENTFUL_SPACE_ID,
+        accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
+        host: process.env.CONTENTFUL_HOST
+      },
     },
   ],
 };


### PR DESCRIPTION
## Description

This PR normalizes on conventions in Gatsby around environment variable naming and fixes some "foot guns" that many users have run into in configuring preview vs. publish environments. Specifically, it does this by unifying around consistent environment variable patterns that swap based on environment:

- `CONTENTFUL_ACCESS_TOKEN`: this is the access token (either Content Delivery API or Content Preview API for Preview)
- `CONTENTFUL_SPACE_ID`: no change here, but the space id which is the same between both
- `CONTENTFUL_HOST`: if using the Content Preview API this has to be `preview.contentful.com` otherwise if unset it defaults to the Content Delivery API CDN

I also augmented the script to clarify this with the .env files that are written.

## Context

This will solve a lot of issues for Contentful and Gatsby users, specifically those that are struggling with setting up consistent environment variables. In fact, this is one of the more common reasons that builds and previews fail on Gatsby Cloud.

What was previously multiple paths (e.g. I have to set HOST, and if I set HOST I have to also set CONTENTFUL_PREVIEW_ACCESS_TOKEN) is now just augmented with consistent environment variables.