### PR TITLE
indents for bulleted and numbered lists

### DIFF
--- a/src/templates/blog-post.module.css
+++ b/src/templates/blog-post.module.css
@@ -91,7 +91,7 @@
   }
 
   .article ul {
-    padding-left: 5;
+    padding-left: 5px;
   }
   
   .article ol {

--- a/src/templates/blog-post.module.css
+++ b/src/templates/blog-post.module.css
@@ -91,6 +91,10 @@
   }
 
   .article ul {
-    padding-left: 0;
+    padding-left: 5;
+  }
+  
+  .article ol {
+    padding-left: 5;
   }
 }

--- a/src/templates/blog-post.module.css
+++ b/src/templates/blog-post.module.css
@@ -95,6 +95,6 @@
   }
   
   .article ol {
-    padding-left: 5;
+    padding-left: 5px;
   }
 }


### PR DESCRIPTION
The current template does not indent bulleted lists in the body of the post. This is the CSS fix. I have also added another class to cover numbered lists as well.