### PR TITLE
Migrate to gatsbyImage from gatsbyImageData

### DIFF
--- a/src/components/article-preview.js
+++ b/src/components/article-preview.js
@@ -18,7 +18,7 @@ const ArticlePreview = ({ posts }) => {
           return (
             <li key={post.slug}>
               <Link to={`/blog/${post.slug}`} className={styles.link}>
-                <GatsbyImage alt="" image={post.heroImage.gatsbyImageData} />
+                <GatsbyImage alt="" image={post.heroImage.gatsbyImage} />
                 <h2 className={styles.title}>{post.title}</h2>
               </Link>
               <div>


### PR DESCRIPTION
gatsbyImageData field is depreciated, migrating to gatsbyImage as per these documents 

One: https://support.gatsbyjs.com/hc/en-us/articles/4426393233171-How-to-Enable-Image-CDN

Two: https://support.gatsbyjs.com/hc/en-us/articles/4522338898579