### PR TITLE
Migrate to gatsbyImage field from gatsbyImageData

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -30,7 +30,7 @@ class BlogPostTemplate extends React.Component {
           image={`http:${post.heroImage.resize.src}`}
         />
         <Hero
-          image={post.heroImage?.gatsbyImageData}
+          image={post.heroImage?.gatsbyImage}
           title={post.title}
           content={post.description}
         />
@@ -89,7 +89,7 @@ export const pageQuery = graphql`
       publishDate(formatString: "MMMM Do, YYYY")
       rawDate: publishDate
       heroImage {
-        gatsbyImageData(layout: FULL_WIDTH, placeholder: BLURRED, width: 1280)
+        gatsbyImage(layout: FULL_WIDTH, placeholder: BLURRED, width: 1280)
         resize(height: 630, width: 1200) {
           src
         }


### PR DESCRIPTION
gatsbyImageData field is depreciated, migrating to gatsbyImage as per these documents 

One: https://support.gatsbyjs.com/hc/en-us/articles/4426393233171-How-to-Enable-Image-CDN

Two: https://support.gatsbyjs.com/hc/en-us/articles/4522338898579