### PR TITLE
Migrate to gatsbyImage field

### DIFF
--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -32,7 +32,7 @@ export const pageQuery = graphql`
         publishDate(formatString: "MMMM Do, YYYY")
         tags
         heroImage {
-          gatsbyImageData(
+          gatsbyImage(
             layout: FULL_WIDTH
             placeholder: BLURRED
             width: 424


### PR DESCRIPTION
gatsbyImageData field is depreciated, migrating to gatsbyImage as per these documents 

One: https://support.gatsbyjs.com/hc/en-us/articles/4426393233171-How-to-Enable-Image-CDN

Two: https://support.gatsbyjs.com/hc/en-us/articles/4522338898579