### PR TITLE
Adding inline images to body of blog post

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -26,7 +26,6 @@ class BlogPostTemplate extends React.Component {
     
     
     const options = {
-      
       renderNode: {
 
         [BLOCKS.EMBEDDED_ASSET]: (node) => {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -27,7 +27,6 @@ class BlogPostTemplate extends React.Component {
     
     const options = {
       renderNode: {
-
         [BLOCKS.EMBEDDED_ASSET]: (node) => {
         const { gatsbyImage, description } = node.data.target
         return (

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -24,7 +24,6 @@ class BlogPostTemplate extends React.Component {
     const plainTextBody = documentToPlainTextString(JSON.parse(post.body.raw))
     const { minutes: timeToRead } = readingTime(plainTextBody)
     
-    
     const options = {
       renderNode: {
         [BLOCKS.EMBEDDED_ASSET]: (node) => {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -37,7 +37,6 @@ class BlogPostTemplate extends React.Component {
          )
         },
       },
-
     };
 
     return (

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -3,6 +3,8 @@ import { Link, graphql } from 'gatsby'
 import get from 'lodash/get'
 import { renderRichText } from 'gatsby-source-contentful/rich-text'
 import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer'
+import { BLOCKS } from '@contentful/rich-text-types'
+import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import readingTime from 'reading-time'
 
 import Seo from '../components/seo'
@@ -21,6 +23,24 @@ class BlogPostTemplate extends React.Component {
     )
     const plainTextBody = documentToPlainTextString(JSON.parse(post.body.raw))
     const { minutes: timeToRead } = readingTime(plainTextBody)
+    
+    
+    const options = {
+      
+      renderNode: {
+
+        [BLOCKS.EMBEDDED_ASSET]: (node) => {
+        const { gatsbyImage, description } = node.data.target
+        return (
+           <GatsbyImage
+              image={getImage(gatsbyImage)}
+              alt={description}
+           />
+         )
+        },
+      },
+
+    };
 
     return (
       <Layout location={this.props.location}>
@@ -42,7 +62,7 @@ class BlogPostTemplate extends React.Component {
           </span>
           <div className={styles.article}>
             <div className={styles.body}>
-              {post.body?.raw && renderRichText(post.body)}
+              {post.body?.raw && renderRichText(post.body, options)}
             </div>
             <Tags tags={post.tags} />
             {(previous || next) && (
@@ -96,6 +116,15 @@ export const pageQuery = graphql`
       }
       body {
         raw
+        references {
+          ... on ContentfulAsset {
+            contentful_id
+            title
+            description
+            gatsbyImage(width: 1000)
+            __typename
+          }
+        }
       }
       tags
       description {


### PR DESCRIPTION
Default behavior is that inline images do not appear in the body of the blog post. This code change allows for images to appear. 

Please note, there is line of CSS that needs to be commented out regarding the behavior of headlines in relation to images. I'll be addressing that in a separate pull request.

Basis for these changes come from this blog post: 

https://www.gatsbyjs.com/blog/how-to-use-the-contentful-rich-text-field-with-gatsby/