### PR TITLE
behavior change to accomodate inline images

### DIFF
--- a/src/templates/blog-post.module.css
+++ b/src/templates/blog-post.module.css
@@ -23,11 +23,6 @@
   max-width: 48rem;
 }
 
-/*.article h2:first-of-type {
-  margin-top: 0;
-}
-*/
-
 .article a {
   border-bottom: 1.5px solid currentColor;
   font-weight: var(--medium);

--- a/src/templates/blog-post.module.css
+++ b/src/templates/blog-post.module.css
@@ -23,9 +23,10 @@
   max-width: 48rem;
 }
 
-.article h2:first-of-type {
+/*.article h2:first-of-type {
   margin-top: 0;
 }
+*/
 
 .article a {
   border-bottom: 1.5px solid currentColor;


### PR DESCRIPTION
This change is related to pull request #211 , so that the headline doesn't crash into the inline image on the first occurrence.