### PR TITLE
remove undefined "reference" type from query

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -112,15 +112,7 @@ export const pageQuery = graphql`
       }
       body {
         raw
-        references {
-          ... on ContentfulAsset {
-            contentful_id
-            title
-            description
-            gatsbyImage(width: 1000)
-            __typename
-          }
-        }
+        
       }
       tags
       description {


### PR DESCRIPTION
the "reference" type is not recognised by the graphql schema at the set up stage. Remove it and apend a note for post-build steps to take if users want to have optional inline images for their posts.